### PR TITLE
rename some options to make the api cleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This project uses postcss to refactor scss code to conform to lint rules that are intended to improve grepability/readability.
 
+## Installation
+
+### Globally via `npm`
+
+```sh
+npm i -g scss-codemods
+```
+
+### Running on-demand
+
+```
+npx scss-codemods [command] [options]
+```
+
 ## `union-class-name`
 
 "Promotes" CSS classes that have the `&-` nesting union selector. Attempts to fix issues flagged by [scss/no-union-class-name](https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/selector-no-union-class-name/README.md) stylelint rule. 
@@ -27,22 +41,22 @@ Intended to improve "grepability" of the selectors that are produced in the brow
 ### Usage
 
 ```bash
-scss-codemods union-class-name --reorder no-reorder <files>
+scss-codemods union-class-name --reorder never <files>
 ```
 
 ### Options
 
 #### `--reorder`
 
-Determines the freedom provided to the codemod to reorder rules to better match the desired format (default: `no-reorder`).
+Determines the freedom provided to the codemod to reorder rules to better match the desired format (default: `never`).
 
 
 **Values:**
-- `no-reorder`: won't promote rules if it would result in the reordering of selectors.
-- `safe-reorder`: will promote rules that result in the reordering of selectors as long as the reordered selectors don't have the same specificity.
-- `unsafe-reorder`: will promote rules regardless of reordering, could result in differing styles if both classes are used on the same element and there's conflicting properties.
+- `never`: won't promote rules if it would result in the reordering of selectors.
+- `safe-only`: will promote rules that result in the reordering of selectors as long as the reordered selectors don't have the same specificity.
+- `allow-unsafe`: will promote rules regardless of reordering, could result in differing styles if both classes are used on the same element and there's conflicting properties.
 
-*Recommended that you test the resulting css thoroughly, especially with the `unsafe-reorder` option.*
+*Recommended that you test the resulting css thoroughly, especially with the `allow-unsafe` option.*
 
 #### `--promote-dollar-vars`
 
@@ -54,11 +68,11 @@ Determines how dollar vars will be promoted (default: `global`). **not implement
 
 #### Not Implemented: `--namespace-dollar-vars`
 
-Determines how dollar var promotion namespacing behavior (default: `no-namespace`).
+Determines how dollar var promotion namespacing behavior (default: `never`).
 
-- `no-namespace`: will promote a dollar var as necessary, will fail if there are duplicate vars at the same level as the promoted var.
-- `namespace-when-necessary`: will namespace a dollar var with the classname it was promoted out of, will still fail if there is a duplicate promoted var.
-- `namespace-always`: will always namespace dollar vars with the classname 
+- `never`: will promote a dollar var as necessary, will fail if there are duplicate vars at the same level as the promoted var.
+- `when-necessary`: will namespace a dollar var with the classname it was promoted out of, will still fail if there is a duplicate promoted var.
+- `always`: will always namespace dollar vars with the classname 
 
 ## `hex-to-tokens`
 

--- a/src/commands/union-class-name.js
+++ b/src/commands/union-class-name.js
@@ -12,8 +12,8 @@ export const builder = {
   r: {
     alias: "reorder",
     describe: "reorder promoted rules rules ",
-    choices: ["no-reorder", "safe-reorder", "unsafe-reorder"],
-    default: "no-reorder",
+    choices: ["never", "safe-only", "allow-unsafe"],
+    default: "never",
   },
   p: {
     alias: "promote-dollar-vars",
@@ -24,8 +24,8 @@ export const builder = {
   n: {
     alias: "namespace-dollar-vars",
     describe: "namespace promoted dollar vars",
-    choices: ["no-namespace", "namespace-when-necessary", "namespace-always"],
-    default: "no-namespace",
+    choices: ["never", "when-necessary", "always"],
+    default: "never",
   },
 };
 

--- a/src/plugins/remove-dash-ampersand.js
+++ b/src/plugins/remove-dash-ampersand.js
@@ -112,20 +112,18 @@ function shouldPromoteNestingSelectorRules(rule, dollarDecls, { Root }, opts) {
     case "NO_CHANGES":
       return true;
     case "SAFE_CHANGES":
-      return (
-        opts.reorder === "safe-reorder" || opts.reorder === "unsafe-reorder"
-      );
+      return opts.reorder === "safe-only" || opts.reorder === "allow-unsafe";
     case "UNSAFE_CHANGES":
-      return opts.reorder === "unsafe-reorder";
+      return opts.reorder === "allow-unsafe";
   }
 }
 
 export default (opts) => {
   opts = {
     // default values
-    reorder: "no-reorder",
+    reorder: "never",
     promoteDollarVars: "global",
-    namespaceDollarVars: "no-namespace",
+    namespaceDollarVars: "never",
     ...opts,
   };
   // Work with options here

--- a/src/plugins/remove-dash-ampersand.test.js
+++ b/src/plugins/remove-dash-ampersand.test.js
@@ -360,10 +360,8 @@ function testCommonBehavior(process) {
 }
 
 describe("remove-dash-ampersand", () => {
-  describe("reorder: no-reorder", () => {
-    const process = createProcessor(
-      removeDashAmpersand({ reorder: "no-reorder" })
-    );
+  describe("reorder: never", () => {
+    const process = createProcessor(removeDashAmpersand({ reorder: "never" }));
 
     testCommonBehavior(process);
 
@@ -427,9 +425,9 @@ describe("remove-dash-ampersand", () => {
     });
   });
 
-  describe("reorder: safe-reorder", () => {
+  describe("reorder: safe-only", () => {
     const process = createProcessor(
-      removeDashAmpersand({ reorder: "safe-reorder" })
+      removeDashAmpersand({ reorder: "safe-only" })
     );
 
     testCommonBehavior(process);
@@ -475,9 +473,9 @@ describe("remove-dash-ampersand", () => {
     });
   });
 
-  describe("reorder: unsafe-reorder", () => {
+  describe("reorder: allow-unsafe", () => {
     const process = createProcessor(
-      removeDashAmpersand({ reorder: "unsafe-reorder" })
+      removeDashAmpersand({ reorder: "allow-unsafe" })
     );
 
     testCommonBehavior(process);


### PR DESCRIPTION
Replace several api option names with shorter, hopefully clearer values. Update README to include installation now that a version is published.